### PR TITLE
添加对 Composer-1 的支持

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,2 @@
-[unstable]
-profile-rustflags = true
-trim-paths = true
+[target.'cfg(all())']
+rustflags = ["-Cdebuginfo=0", "-Zthreads=8"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["trim-paths"]
+
 [package]
 name = "cursor-api"
 version = "0.3.6-2"
@@ -85,7 +87,6 @@ strip = true
 # panic = 'unwind'
 opt-level = 3
 trim-paths = "all"
-rustflags = ["-Cdebuginfo=0", "-Zthreads=8"]
 
 [features]
 default = ["webpki-roots"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/core/constant.rs
+++ b/src/core/constant.rs
@@ -107,6 +107,7 @@ def_const_models!(
 
     // Cursor 模型
     CURSOR_SMALL => "cursor-small",
+    COMPOSER_1 => "composer-1",
 
     // Google 模型
     GEMINI_2_5_PRO_PREVIEW_05_06 => "gemini-2.5-pro-preview-05-06",
@@ -608,6 +609,7 @@ create_models! {
     CURSOR => [
         ModelIds::new(CURSOR_SMALL),
         ModelIds::new(CURSOR_FAST),
+        ModelIds::new(COMPOSER_1),
     ],
 
     GOOGLE => [


### PR DESCRIPTION
修复 #30
此拉取请求引入了多项配置和代码更新，旨在提高构建的可复现性、启用新的模型支持并更新工具链的使用。主要更改集中在 Cargo 的构建设置、新增模型标识符以及指定 Rust 工具链版本上。

**构建配置更新：**

* 修改了 `.cargo/config.toml` 文件，为所有目标设置了 `rustflags`，从而启用零调试信息和多线程编译，以提高构建性能。

* 更新了 `Cargo.toml` 文件，使用 `trim-paths` 功能来实现可复现的构建，并从 profile 部分移除了冗余的 `rustflags`。 [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R1-R2) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L88)

**工具链规范：**

* 添加了 `rust-toolchain.toml` 文件，用于显式地将工具链通道设置为 nightly，以确保与不稳定版本的功能兼容。

**模型支持增强：**

* 在 `src/core/constant.rs` 中添加了 `COMPOSER_1` 模型标识符，并将其包含在 `CURSOR` 模型组中，从而扩展了支持的模型范围。[[1]](diffhunk://#diff-2f27d226ded0221b3d01e306640ad1081bd360e39bfd86ce9ffda6d2dee941b7R110) [[2]](diffhunk://#diff-2f27d226ded0221b3d01e306640ad1081bd360e39bfd86ce9ffda6d2dee941b7R612)